### PR TITLE
fix when have x error and 0 error at same time

### DIFF
--- a/check_swift_object_servers
+++ b/check_swift_object_servers
@@ -59,12 +59,12 @@ fi
 CHECK=$(swift-recon --md5 | grep ' error')
 echo $CHECK
 
-if echo "$CHECK" | grep -q ' 0 error'
-then
-    exit $STATE_OK
-elif echo "$CHECK" | grep -q ' 1 error'
+if echo "$CHECK" | grep -q ' 1 error'
 then
     exit $STATE_WARNING
-else
+elif echo "$CHECK" | grep -v ' 0 error' | grep -q ' error'
+then
     exit $STATE_CRITICAL
+else
+    exit $STATE_OK
 fi


### PR DESCRIPTION
This check returns STATE_OK when have the following error:
`
===============================================================================
--> Starting reconnaissance on 6 hosts (object)
===============================================================================
[2018-09-13 13:23:55] Checking ring md5sums
...
1/6 hosts matched, 5 error[s] while checking hosts.
===============================================================================
[2018-09-13 13:23:55] Checking swift.conf md5sum
6/6 hosts matched, 0 error[s] while checking hosts.
===============================================================================
`